### PR TITLE
chore: add one-click production deploy workflow

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,4 +1,5 @@
 # main 브랜치에 반영된 커밋만 원격 프로덕션 배포 (작업 브랜치 배포 없음)
+# 수동 배포: Actions 「Deploy production (manual)」— deploy-production.yml
 
 name: Deploy production
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,110 @@
+# 운영 서버 수동 배포 (workflow_dispatch, OpenSSH 키 파일 방식)
+# - PR 검증: production-deploy.yml (별도)
+# - main push 자동 배포: deploy-main.yml (별도)
+
+name: Deploy production (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "배포할 Git 브랜치 (origin 기준)"
+        required: true
+        default: "main"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production-manual
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+      DEPLOY_APP_DIR: ${{ secrets.DEPLOY_APP_DIR }}
+      GIT_REF: ${{ github.event.inputs.branch }}
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+
+      - name: Write SSH private key to file
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+      - name: Register known_hosts (ssh-keyscan)
+        run: |
+          set -euo pipefail
+          ssh-keyscan -p "${DEPLOY_PORT}" -H "${DEPLOY_HOST}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: SSH connectivity test
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" "echo SSH_OK"
+
+      - name: Server — git fetch / checkout / pull
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "set -euo pipefail; cd \"${DEPLOY_APP_DIR}\"; git fetch origin; git checkout \"${GIT_REF}\"; git pull origin \"${GIT_REF}\""
+
+      - name: Server — bash deploy/deploy-prod.sh
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "set -euo pipefail; cd \"${DEPLOY_APP_DIR}\"; bash deploy/deploy-prod.sh"
+
+      - name: Server — systemctl status malmoi-web
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "set -euo pipefail; systemctl status malmoi-web --no-pager"
+
+      - name: Server — curl health (127.0.0.1:3000)
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "set -euo pipefail; curl -fsSI --max-time 25 http://127.0.0.1:3000/ | head -n 30"
+
+      - name: Server — curl health (https://portal.hanguru.school/)
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "set -euo pipefail; curl -fsSI --max-time 30 https://portal.hanguru.school/ | head -n 30"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 개발/스테이징 루틴: `docs/dev-and-staging-workflow.md`
 - 운영 대응 매뉴얼: `docs/operations-runbook.md`
 - **Git 기반 서버 배포**: `docs/DEPLOY_GIT.md`（`npm run deploy` / Cursor Task）
+- **Actions에서 버튼 배포**: `docs/deploy-one-click-ko.md`（`.github/workflows/deploy-production.yml`）
 
 ## Git 배포 (요약)
 

--- a/app/student/reservations/page.js
+++ b/app/student/reservations/page.js
@@ -14,7 +14,7 @@ export default async function StudentReservationsPage({ searchParams }) {
       title="予約"
       subtitle={
         useV2
-          ? "日付と時間を選んで予約し、一覧から変更・キャンセルできます。"
+          ? "残り時間を確認しながら、レッスン→日付→時間の順で簡単に予約できます。ポイントは利用明細でご確認ください。"
           : "段階ごとに選択しながら予約を作成し、自分の予約を確認・変更できます。"
       }
     >

--- a/deploy/deploy-prod.sh
+++ b/deploy/deploy-prod.sh
@@ -10,7 +10,9 @@
 
 set -euo pipefail
 
-APP_DIR="/home/malmoi_deploy/apps/malmoi"
+# 任意: GitHub Actions 手動デプロイ等から上書き（既定は従来どおり main / 固定パス）
+APP_DIR="${DEPLOY_APP_DIR:-/home/malmoi_deploy/apps/malmoi}"
+GIT_REF="${DEPLOY_GIT_REF:-main}"
 SERVICE_NAME="${MALMOI_SYSTEMD_SERVICE:-malmoi-web}"
 INTERNAL_HEALTH_URL="http://127.0.0.1:3000/login"
 EXTERNAL_HEALTH_URL="https://portal.hanguru.school/login"
@@ -46,6 +48,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 echo "=============================================="
 echo "MalMoi PROD deploy | $(date -Is)"
 echo "APP_DIR=$APP_DIR"
+echo "GIT_REF=$GIT_REF"
 echo "SERVICE=$SERVICE_NAME"
 echo "MALMOI_USE_RELEASES=$USE_RELEASES"
 echo "LOG=$LOG_FILE"
@@ -59,11 +62,12 @@ release_deploy_failed_cleanup() {
 }
 
 if [[ "$USE_RELEASES" == "1" ]]; then
-  echo "[release 1/8] git fetch"
-  git fetch origin main
+  echo "[release 1/8] git fetch origin $GIT_REF"
+  git fetch origin "$GIT_REF"
 
-  echo "[release 2/8] git pull origin main (ff-only)"
-  git pull --ff-only origin main
+  echo "[release 2/8] git checkout tracking branch $GIT_REF (ff-only)"
+  git checkout -B "$GIT_REF" "origin/$GIT_REF"
+  git pull --ff-only origin "$GIT_REF"
 
   REL_ID="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
   REL_PATH="${APP_DIR}/releases/${REL_ID}"
@@ -150,11 +154,12 @@ if [[ "$USE_RELEASES" == "1" ]]; then
   exit 0
 fi
 
-echo "[1/7] git fetch"
-git fetch origin main
+echo "[1/7] git fetch origin $GIT_REF"
+git fetch origin "$GIT_REF"
 
-echo "[2/7] git pull origin main (ff-only)"
-git pull --ff-only origin main
+echo "[2/7] git checkout tracking branch $GIT_REF (ff-only)"
+git checkout -B "$GIT_REF" "origin/$GIT_REF"
+git pull --ff-only origin "$GIT_REF"
 
 echo "[3/7] install dependencies (include dev for build)"
 if [[ -f package-lock.json ]]; then

--- a/docs/deploy-one-click-ko.md
+++ b/docs/deploy-one-click-ko.md
@@ -1,0 +1,48 @@
+# 본番 배포 (Actions 버튼 한 번)
+
+워크플로 파일: `.github/workflows/deploy-production.yml`  
+Actions 표시 이름: **Deploy production (manual)**
+
+## 어디서 버튼을 누르나요
+
+1. GitHub 저장소 **Actions** 탭
+2. 왼쪽 목록에서 **Deploy production (manual)** 선택
+3. 오른쪽 **Run workflow** → **branch** 확인(기본 `main`) 후 **Run workflow** 실행
+
+## 브랜치는 무엇을 고르나요
+
+- **branch** 입력: 서버에서 `git checkout`·`git pull` 할 **origin 브랜치 이름**입니다.  
+- 운영 기본값은 **`main`** 입니다.
+
+## 성공·실패는 어디서 보나요
+
+- 같은 실행 건을 열고 **각 Step 로그**를 봅니다. 실패한 단계에 빨간 표시가 나며, **exit code**가 그대로 반영됩니다.
+- PR용 빌드 검증은 **Production Deployment** (`production-deploy.yml`) — 이름·트리거가 다릅니다.
+
+## 필요한 Repository Secrets
+
+| 이름 | 용도 |
+|------|------|
+| `DEPLOY_HOST` | SSH 호스트 |
+| `DEPLOY_USER` | SSH 사용자 |
+| `DEPLOY_PORT` | SSH 포트 (예: `22`) |
+| `DEPLOY_APP_DIR` | 서버 앱 루트 (예: `/home/malmoi_deploy/apps/malmoi`) |
+| `DEPLOY_SSH_KEY` | 배포용 개인키 (PEM 전체) |
+
+`environment: production` 을 쓰므로, 환경별 Secrets가 있으면 그쪽 값이 우선될 수 있습니다.
+
+## 실행 순서 (요약)
+
+1. 저장소 checkout  
+2. SSH 키 파일 생성·권한(`600`)  
+3. `known_hosts` 등록  
+4. SSH 접속 테스트  
+5. 서버: `cd` → `git fetch` → `git checkout` → `git pull`  
+6. 서버: `bash deploy/deploy-prod.sh`  
+7. 서버: `systemctl status malmoi-web`  
+8. 서버: `curl` 로컬·공개 URL 헬스 확인  
+
+## main 머지 시 자동 배포로 바꾸려면
+
+- 이미 **main push** 시 자동 배포는 `.github/workflows/deploy-main.yml` (**Deploy production**) 에서 동작하도록 둘 수 있습니다.  
+- 수동 워크플로만 쓰려면 `deploy-main.yml`의 `on.push` 를 제거하거나 비활성화하면 됩니다.

--- a/features/reservations/adapters/studentReservationsAdapter.js
+++ b/features/reservations/adapters/studentReservationsAdapter.js
@@ -4,7 +4,9 @@
 
 export {
   fetchStudentReservations,
+  fetchStudentLessonTypes,
   fetchStudentReservationSlots,
+  fetchStudentReservationCandidates,
   patchStudentReservation,
   postStudentReservation,
   postStudentReservationCancel,

--- a/features/reservations/ui/student/LessonTypeCard.js
+++ b/features/reservations/ui/student/LessonTypeCard.js
@@ -1,0 +1,25 @@
+"use client";
+
+import flow from "./student-reservation-flow.module.css";
+
+function modeLabel(lessonMode) {
+  const m = String(lessonMode || "").trim();
+  if (m === "group") return "グループ";
+  if (m === "pair") return "ペア";
+  return "1対1";
+}
+
+export default function LessonTypeCard({ lesson, selected, deliveryLabel, onSelect }) {
+  return (
+    <button
+      type="button"
+      className={`${flow.lessonCard} ${selected ? flow.lessonCardOn : ""}`}
+      onClick={() => onSelect(lesson)}
+    >
+      <div className={flow.lessonName}>{lesson.displayName || "レッスン"}</div>
+      <div className={flow.lessonMeta}>
+        {lesson.durationMinutes}分 · {deliveryLabel} · {modeLabel(lesson.lessonMode)}
+      </div>
+    </button>
+  );
+}

--- a/features/reservations/ui/student/StudentReservationCalendar.js
+++ b/features/reservations/ui/student/StudentReservationCalendar.js
@@ -1,0 +1,86 @@
+"use client";
+
+import flow from "./student-reservation-flow.module.css";
+
+export default function StudentReservationCalendar({
+  calendarMonth,
+  today,
+  maxDate,
+  selectedDate,
+  onSelectDate,
+  onPrevMonth,
+  onNextMonth,
+  getDayMeta,
+}) {
+  const start = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1);
+  const end = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0);
+  const leading = start.getDay();
+  const cells = [];
+  for (let i = 0; i < leading; i += 1) {
+    cells.push({ key: `b-${i}`, blank: true });
+  }
+  for (let day = 1; day <= end.getDate(); day += 1) {
+    const current = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), day);
+    const y = current.getFullYear();
+    const m = String(current.getMonth() + 1).padStart(2, "0");
+    const d = String(day).padStart(2, "0");
+    const dateKey = `${y}-${m}-${d}`;
+    cells.push({ key: dateKey, blank: false, dateKey, label: String(day), current });
+  }
+
+  const monthStart = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1);
+  const canPrev = monthStart > new Date(today.getFullYear(), today.getMonth(), 1);
+  const canNext = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0) < maxDate;
+
+  return (
+    <div>
+      <div className={flow.calHeader}>
+        <button type="button" className={flow.calNav} onClick={onPrevMonth} disabled={!canPrev}>
+          前月
+        </button>
+        <strong>
+          {calendarMonth.getFullYear()}年 {calendarMonth.getMonth() + 1}月
+        </strong>
+        <button type="button" className={flow.calNav} onClick={onNextMonth} disabled={!canNext}>
+          翌月
+        </button>
+      </div>
+      <div className={flow.calWeekdays}>
+        {["日", "月", "火", "水", "木", "金", "土"].map((w) => (
+          <span key={w}>{w}</span>
+        ))}
+      </div>
+      <div className={flow.calGrid}>
+        {cells.map((cell) => {
+          if (cell.blank) return <span key={cell.key} className={flow.calBlank} />;
+          const outOfRange = cell.current < today || cell.current > maxDate;
+          const meta = getDayMeta(cell.dateKey);
+          const disabled = outOfRange || meta.disabled;
+          let cls = flow.calDay;
+          if (!disabled) {
+            if (meta.bookable) cls += ` ${flow.calDayOk}`;
+            else if (meta.hasSlots) cls += ` ${flow.calDayWeak}`;
+          }
+          if (selectedDate === cell.dateKey) cls += ` ${flow.calDaySel}`;
+          return (
+            <button
+              key={cell.key}
+              type="button"
+              disabled={disabled}
+              className={cls}
+              title={meta.hint || ""}
+              onClick={() => {
+                if (!disabled) onSelectDate(cell.dateKey);
+              }}
+            >
+              {cell.label}
+              {meta.hint && !disabled && meta.bookable === false ? (
+                <span className={flow.dayHint}>{meta.hint}</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/features/reservations/ui/student/StudentReservationConfirmCard.js
+++ b/features/reservations/ui/student/StudentReservationConfirmCard.js
@@ -1,0 +1,69 @@
+"use client";
+
+import { lessonDeliveryLabel } from "../../../../lib/adapters/studentReservationView";
+import flow from "./student-reservation-flow.module.css";
+
+export default function StudentReservationConfirmCard({
+  lessonName,
+  date,
+  startTime,
+  endTime,
+  teacherName,
+  durationMinutes,
+  useMinutes,
+  afterMinutes,
+  deliveryType,
+  memo,
+  onMemoChange,
+}) {
+  return (
+    <div className={flow.confirmCard}>
+      <div className={flow.confirmRow}>
+        <span className={flow.confirmKey}>レッスン</span>
+        <span className={flow.confirmVal}>{lessonName || "—"}</span>
+      </div>
+      <div className={flow.confirmRow}>
+        <span className={flow.confirmKey}>日付</span>
+        <span className={flow.confirmVal}>{date || "—"}</span>
+      </div>
+      <div className={flow.confirmRow}>
+        <span className={flow.confirmKey}>時間</span>
+        <span className={flow.confirmVal}>
+          {startTime || "—"}
+          {endTime ? ` 〜 ${endTime}` : ""}
+        </span>
+      </div>
+      <div className={flow.confirmRow}>
+        <span className={flow.confirmKey}>担当講師</span>
+        <span className={flow.confirmVal}>{teacherName || "調整"}</span>
+      </div>
+      <div className={flow.confirmRow}>
+        <span className={flow.confirmKey}>形式</span>
+        <span className={flow.confirmVal}>{lessonDeliveryLabel(deliveryType)}</span>
+      </div>
+      <div className={flow.confirmRow}>
+        <span className={flow.confirmKey}>所要時間</span>
+        <span className={flow.confirmVal}>{durationMinutes != null ? `${durationMinutes}分` : "—"}</span>
+      </div>
+      <div className={flow.impactBox}>
+        <div className={flow.impactTitle}>今回の予約で使う時間</div>
+        <div className={flow.impactLine}>{useMinutes != null ? `${useMinutes}分` : "—"}</div>
+        <div className={flow.impactTitle} style={{ marginTop: "0.45rem" }}>
+          予約後の残り時間
+        </div>
+        <div className={flow.impactLine}>{afterMinutes != null ? `${afterMinutes}分` : "—"}</div>
+      </div>
+      <label className={flow.hint} style={{ display: "block", marginTop: "0.65rem" }}>
+        <span style={{ display: "block", fontWeight: 700, marginBottom: "0.25rem", color: "#334155" }}>
+          伝えたいこと（任意）
+        </span>
+        <input
+          className={flow.field}
+          value={memo}
+          onChange={(e) => onMemoChange(e.target.value)}
+          placeholder="教室への連絡事項"
+        />
+      </label>
+    </div>
+  );
+}

--- a/features/reservations/ui/student/StudentReservationDetailModal.js
+++ b/features/reservations/ui/student/StudentReservationDetailModal.js
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  addDays,
+  blockedText,
+  formatDateKey,
+  lessonDeliveryLabel,
+  startOfDay,
+} from "../../../../lib/adapters/studentReservationView";
+import { fetchStudentReservationCandidates } from "../../../../lib/adapters/studentReservationClient";
+import StudentReservationStatusBadge from "./StudentReservationStatusBadge";
+import StudentTimeCandidateList from "./StudentTimeCandidateList";
+import flow from "./student-reservation-flow.module.css";
+
+export default function StudentReservationDetailModal({
+  open,
+  reservation,
+  onClose,
+  onCancel,
+  onReschedule,
+  cancelBusy,
+  rescheduleBusy,
+}) {
+  const [candidates, setCandidates] = useState([]);
+  const [pick, setPick] = useState(null);
+  const [loadErr, setLoadErr] = useState("");
+
+  const self = reservation?.selfService || {};
+  const lessonId = String(reservation?.lessonServiceId || "").trim();
+
+  useEffect(() => {
+    if (!open || !reservation || !lessonId) {
+      setCandidates([]);
+      setPick(null);
+      setLoadErr("");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setLoadErr("");
+      try {
+        const base = startOfDay(new Date());
+        const fromDate = formatDateKey(base);
+        const toDate = formatDateKey(addDays(base, 56));
+        const data = await fetchStudentReservationCandidates({
+          lessonTypeId: lessonId,
+          fromDate,
+          toDate,
+          lessonMode: reservation.lessonDeliveryType || "in_person",
+        });
+        if (cancelled) return;
+        const rows = (data.candidates || []).filter(
+          (c) => c.bookingOk && String(c.slotId) !== String(reservation.slotId)
+        );
+        setCandidates(rows.sort((a, b) => `${a.date} ${a.startTime}`.localeCompare(`${b.date} ${b.startTime}`)));
+      } catch (e) {
+        if (!cancelled) {
+          setLoadErr(e.message || "候補の読み込みに失敗しました。");
+          setCandidates([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, reservation, lessonId]);
+
+  const canChange = Boolean(self.canStudentChange);
+  const canCancel = Boolean(self.canStudentCancel);
+
+  const blockHint = useMemo(() => {
+    if (!self.blockedReasonChange && !self.blockedReasonCancel) return "";
+    return blockedText(self.blockedReasonChange || self.blockedReasonCancel);
+  }, [self.blockedReasonChange, self.blockedReasonCancel]);
+
+  if (!open || !reservation) return null;
+
+  return (
+    <div className={flow.modalRoot} role="dialog" aria-modal="true" aria-label="予約の詳細">
+      <button type="button" className={flow.modalBackdrop} aria-label="閉じる" onClick={onClose} />
+      <div className={flow.modalCard}>
+        <button type="button" className={flow.modalClose} aria-label="閉じる" onClick={onClose}>
+          ×
+        </button>
+        <h3 className={flow.modalTitle}>{reservation.studentNameKanji || "ご予約"}</h3>
+        <StudentReservationStatusBadge status={reservation.status} attendanceStatus={reservation.attendanceStatus} />
+        <p className={flow.hint} style={{ marginTop: "0.5rem" }}>
+          <strong>
+            {reservation.date} {String(reservation.time || "").slice(0, 5)}
+          </strong>
+          <br />
+          {reservation.lessonServiceNameJa || "レッスン"} · {lessonDeliveryLabel(reservation.lessonDeliveryType)}
+          <br />
+          担当: {reservation.instructorName || "—"}
+        </p>
+        <p className={flow.hint}>
+          変更: {canChange ? "可" : "不可"} / キャンセル: {canCancel ? "可" : "不可"}
+          {blockHint ? ` — ${blockHint}` : ""}
+        </p>
+        {reservation.expectedPointsConsume != null ? (
+          <p className={flow.hint} style={{ fontSize: "0.7rem", color: "#94a3b8" }}>
+            ポイント目安: {reservation.expectedPointsConsume}pt（詳細は
+            <Link href="/student/lesson-time">レッスン時間・利用</Link>
+            でもご確認ください）
+          </p>
+        ) : null}
+
+        {canChange && lessonId ? (
+          <div style={{ marginTop: "0.75rem" }}>
+            <p className={flow.hint} style={{ fontWeight: 700, color: "#334155" }}>
+              変更先の時間を選ぶ
+            </p>
+            {loadErr ? <p className={flow.hint}>{loadErr}</p> : null}
+            <StudentTimeCandidateList
+              candidates={candidates.slice(0, 24)}
+              selectedSlotId={pick?.slotId || ""}
+              onSelect={(c) => setPick(c)}
+            />
+            <button
+              type="button"
+              className={`${flow.modalBtn} ${flow.modalBtnPrimary}`}
+              style={{ marginTop: "0.5rem", width: "100%" }}
+              disabled={!pick || rescheduleBusy}
+              onClick={() => onReschedule(reservation.id, pick.slotId)}
+            >
+              {rescheduleBusy ? "変更中…" : "変更する"}
+            </button>
+          </div>
+        ) : null}
+
+        <div className={flow.modalActions}>
+          {canCancel ? (
+            <button
+              type="button"
+              className={`${flow.modalBtn} ${flow.modalBtnDanger}`}
+              disabled={cancelBusy}
+              onClick={() => onCancel(reservation.id)}
+            >
+              {cancelBusy ? "処理中…" : "キャンセルする"}
+            </button>
+          ) : null}
+          <Link href="/student/lesson-time" className={flow.modalBtn} style={{ textAlign: "center", lineHeight: 2.4 }}>
+            詳細を見る（時間・利用）
+          </Link>
+          <button type="button" className={flow.modalBtn} onClick={onClose}>
+            閉じる
+          </button>
+        </div>
+        {canCancel ? (
+          <p className={flow.hint} style={{ marginTop: "0.5rem" }}>
+            キャンセル規定に基づき処理されます。教室からの確認が必要な場合があります。
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/features/reservations/ui/student/StudentReservationStatusBadge.js
+++ b/features/reservations/ui/student/StudentReservationStatusBadge.js
@@ -1,0 +1,19 @@
+"use client";
+
+import { statusMeta } from "../../../../lib/adapters/studentReservationView";
+import flow from "./student-reservation-flow.module.css";
+
+export default function StudentReservationStatusBadge({ status, attendanceStatus }) {
+  const st = statusMeta(status, attendanceStatus);
+  const cls =
+    st.tone === "pending"
+      ? flow.badgePending
+      : st.tone === "confirmed"
+        ? flow.badgeConfirmed
+        : st.tone === "cancelled"
+          ? flow.badgeCancelled
+          : st.tone === "completed"
+            ? flow.badgeCompleted
+            : flow.badgePending;
+  return <span className={`${flow.badge} ${cls}`}>{st.label}</span>;
+}

--- a/features/reservations/ui/student/StudentReservationSummary.js
+++ b/features/reservations/ui/student/StudentReservationSummary.js
@@ -1,0 +1,47 @@
+"use client";
+
+import flow from "./student-reservation-flow.module.css";
+
+export default function StudentReservationSummary({
+  remainingMinutes = null,
+  bookableMinutes = null,
+  nextReservationLabel = "",
+  useMinutes = null,
+  afterMinutes = null,
+  loading = false,
+}) {
+  return (
+    <div className={flow.summaryGrid} aria-label="予約に関する時間の概要">
+      <div className={flow.summaryCard}>
+        <span className={flow.summaryLabel}>残り時間</span>
+        <span className={flow.summaryValue}>
+          {loading ? "…" : remainingMinutes != null ? `${remainingMinutes}分` : "—"}
+        </span>
+        <span className={flow.summaryHint}>レッスンに使える残り</span>
+      </div>
+      <div className={flow.summaryCard}>
+        <span className={flow.summaryLabel}>予約可能時間</span>
+        <span className={flow.summaryValue}>
+          {loading ? "…" : bookableMinutes != null ? `${bookableMinutes}分` : "—"}
+        </span>
+        <span className={flow.summaryHint}>規則上、予約に使える時間（目安）</span>
+      </div>
+      <div className={flow.summaryCard}>
+        <span className={flow.summaryLabel}>次回予約</span>
+        <span className={flow.summaryValue} style={{ fontSize: "0.82rem", lineHeight: 1.35 }}>
+          {nextReservationLabel || "次回予約なし"}
+        </span>
+      </div>
+      <div className={flow.summaryCard}>
+        <span className={flow.summaryLabel}>今回の予約で使う時間</span>
+        <span className={flow.summaryValue}>{useMinutes != null ? `${useMinutes}分` : "—"}</span>
+        <span className={flow.summaryHint}>レッスンを選ぶと表示</span>
+      </div>
+      <div className={flow.summaryCard}>
+        <span className={flow.summaryLabel}>予約後の残り時間</span>
+        <span className={flow.summaryValue}>{afterMinutes != null ? `${afterMinutes}分` : "—"}</span>
+        <span className={flow.summaryHint}>時間を選ぶと表示</span>
+      </div>
+    </div>
+  );
+}

--- a/features/reservations/ui/student/StudentReservationsApp.js
+++ b/features/reservations/ui/student/StudentReservationsApp.js
@@ -1,180 +1,156 @@
 "use client";
 
 /**
- * 学生予約 V2（features/reservations/ui）
- * API・保存形式は lib/adapters のクライアント経由で既存契約を維持
+ * 学生予約 V2：時間中心・段階型（エンジン: /api/student/reservation-candidates 共有）
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import styles from "../../../../app/login/login.module.css";
 import v2 from "./reservations-app.module.css";
+import flow from "./student-reservation-flow.module.css";
 import {
   buildStudentReservationCreatePayload,
-  fetchStudentReservationSlots,
+  fetchStudentLessonTypes,
+  fetchStudentReservationCandidates,
   fetchStudentReservations,
   patchStudentReservation,
   postStudentReservation,
   postStudentReservationCancel,
 } from "../../adapters/studentReservationsAdapter";
-import {
-  addDays,
-  blockedText,
-  formatDateKey,
-  lessonDeliveryLabel,
-  parseDateKey,
-  slotLabel,
-  startOfDay,
-  statusMeta,
-  toMinutes,
-} from "../../../../lib/adapters/studentReservationView";
+import { addDays, formatDateKey, parseDateKey, startOfDay } from "../../../../lib/adapters/studentReservationView";
+import { studentFacingUnavailableHint } from "../../../../lib/student/studentReservationReasonStudentJa";
+import StudentReservationSummary from "./StudentReservationSummary";
+import LessonTypeCard from "./LessonTypeCard";
+import StudentReservationCalendar from "./StudentReservationCalendar";
+import StudentTimeCandidateList from "./StudentTimeCandidateList";
+import StudentReservationConfirmCard from "./StudentReservationConfirmCard";
+import StudentReservationDetailModal from "./StudentReservationDetailModal";
+import { lessonDeliveryLabel, statusMeta } from "../../../../lib/adapters/studentReservationView";
 
-const INSTRUCTOR_NO_PREFERENCE = "__no_preference__";
+const STEPS = ["レッスン", "日付", "時間", "確認", "完了"];
 
-function badgeClass(tone) {
-  if (tone === "pending") return v2.badgePending;
-  if (tone === "confirmed") return v2.badgeConfirmed;
-  if (tone === "cancelled") return v2.badgeCancelled;
-  if (tone === "completed") return v2.badgeCompleted;
-  return v2.badgeScheduled;
+function deliveryLabelShort(id) {
+  return id === "online" ? "オンライン" : "対面";
+}
+
+function badgeToneClass(tone) {
+  if (tone === "pending") return flow.badgePending;
+  if (tone === "confirmed") return flow.badgeConfirmed;
+  if (tone === "cancelled") return flow.badgeCancelled;
+  if (tone === "completed") return flow.badgeCompleted;
+  return flow.badgePending;
 }
 
 export default function StudentReservationsApp() {
   const [mainTab, setMainTab] = useState("reserve");
-  const [wizardStep, setWizardStep] = useState(1);
+  const [step, setStep] = useState(1);
+
+  const [lessonTypes, setLessonTypes] = useState([]);
+  const [selectedLesson, setSelectedLesson] = useState(null);
+  const [lessonDeliveryType, setLessonDeliveryType] = useState("in_person");
 
   const [reservations, setReservations] = useState([]);
-  const [slots, setSlots] = useState([]);
-  const [instructorAssignmentMode, setInstructorAssignmentMode] = useState("auto");
   const [loading, setLoading] = useState(true);
+  const [monthLoading, setMonthLoading] = useState(false);
   const [error, setError] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
 
-  const [form, setForm] = useState({
-    slotId: "",
-    lessonDeliveryType: "in_person",
-    memo: "",
-  });
-  const [rescheduleSlotByReservation, setRescheduleSlotByReservation] = useState({});
-  const [saving, setSaving] = useState(false);
   const [lessonUsage, setLessonUsage] = useState(null);
-  const [selectedTeacherId, setSelectedTeacherId] = useState("");
-  const [selectedDate, setSelectedDate] = useState("");
+  const [monthPayload, setMonthPayload] = useState(null);
+
   const [calendarMonth, setCalendarMonth] = useState(() => {
-    const now = new Date();
-    return new Date(now.getFullYear(), now.getMonth(), 1);
+    const n = new Date();
+    return new Date(n.getFullYear(), n.getMonth(), 1);
   });
+  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedCandidate, setSelectedCandidate] = useState(null);
+
+  const [form, setForm] = useState({ memo: "" });
+  const [saving, setSaving] = useState(false);
+
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detailReservation, setDetailReservation] = useState(null);
+  const [cancelBusy, setCancelBusy] = useState(false);
+  const [rescheduleBusy, setRescheduleBusy] = useState(false);
 
   const today = useMemo(() => startOfDay(new Date()), []);
   const maxDate = useMemo(() => addDays(today, 365), [today]);
-  const bookableSlots = useMemo(() => slots.filter((slot) => slot.isBookable), [slots]);
-  const teacherOptions = useMemo(() => {
-    const map = new Map();
-    slots.forEach((slot) => {
-      if (!slot.instructorUserId) return;
-      map.set(slot.instructorUserId, {
-        id: slot.instructorUserId,
-        name: slot.instructorName || "未設定",
-      });
-    });
-    return [...map.values()].sort((a, b) => a.name.localeCompare(b.name));
-  }, [slots]);
-  const canStudentSelectInstructor =
-    instructorAssignmentMode === "student_select" || instructorAssignmentMode === "hybrid";
-  const filteredByCourse = slots;
-  const filteredByTeacher = useMemo(() => {
-    if (!canStudentSelectInstructor) return filteredByCourse;
-    if (teacherOptions.length === 0) return filteredByCourse;
-    if (!selectedTeacherId || selectedTeacherId === INSTRUCTOR_NO_PREFERENCE) return filteredByCourse;
-    return filteredByCourse.filter((slot) => slot.instructorUserId === selectedTeacherId);
-  }, [canStudentSelectInstructor, filteredByCourse, selectedTeacherId, teacherOptions.length]);
 
-  const dateStatsMap = useMemo(() => {
-    const map = new Map();
-    filteredByTeacher.forEach((slot) => {
-      if (!slot.date) return;
-      const dateObj = parseDateKey(slot.date);
-      if (dateObj < today || dateObj > maxDate) return;
-      const prev = map.get(slot.date) || { hasAny: false, hasBookable: false };
-      prev.hasAny = true;
-      prev.hasBookable = prev.hasBookable || Boolean(slot.isBookable);
-      map.set(slot.date, prev);
-    });
-    return map;
-  }, [filteredByTeacher, today, maxDate]);
+  const remainingMinutes = lessonUsage?.lessonMinutes?.remainingMinutes ?? null;
+  const snapRemaining = monthPayload?.studentSnapshot?.remainingMinutes ?? null;
+  const bookableMinutes = snapRemaining != null ? snapRemaining : remainingMinutes;
 
-  const availableDateKeys = useMemo(() => [...dateStatsMap.keys()].sort(), [dateStatsMap]);
-  const firstBookableDate = useMemo(
-    () => availableDateKeys.find((date) => dateStatsMap.get(date)?.hasBookable) || "",
-    [availableDateKeys, dateStatsMap]
-  );
+  const nextReservationLabel = useMemo(() => {
+    const rows = [...(reservations || [])].filter((r) => !["cancelled", "rejected"].includes(String(r.status || "")));
+    const todayKey = formatDateKey(today);
+    rows.sort((a, b) => `${a.date} ${a.time}`.localeCompare(`${b.date} ${b.time}`));
+    const upcoming = rows.find((r) => `${r.date}`.slice(0, 10) >= todayKey);
+    if (!upcoming) return "";
+    return `${upcoming.date} ${String(upcoming.time || "").slice(0, 5)}（${upcoming.lessonServiceNameJa || "レッスン"}）`;
+  }, [reservations, today]);
 
-  const slotsForDate = useMemo(() => {
-    if (!selectedDate) return [];
-    return filteredByTeacher
-      .filter((slot) => slot.date === selectedDate)
-      .sort((a, b) => toMinutes(a.time) - toMinutes(b.time));
-  }, [filteredByTeacher, selectedDate]);
+  const useMinutes = selectedLesson?.durationMinutes ?? null;
+  const afterMinutes = useMemo(() => {
+    if (selectedCandidate?.remainingMinutesAfterBooking != null) return selectedCandidate.remainingMinutesAfterBooking;
+    if (useMinutes != null && remainingMinutes != null) return Math.max(0, remainingMinutes - useMinutes);
+    return null;
+  }, [selectedCandidate, useMinutes, remainingMinutes]);
 
-  const selectedSlot = useMemo(
-    () => slotsForDate.find((slot) => slot.id === form.slotId) || null,
-    [slotsForDate, form.slotId]
-  );
+  const monthRange = useMemo(() => {
+    const y = calendarMonth.getFullYear();
+    const m = calendarMonth.getMonth();
+    const first = new Date(y, m, 1);
+    const last = new Date(y, m + 1, 0);
+    return { fromDate: formatDateKey(first), toDate: formatDateKey(last) };
+  }, [calendarMonth]);
 
-  const calendarCells = useMemo(() => {
-    const start = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1);
-    const end = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0);
-    const leading = start.getDay();
-    const cells = [];
-    for (let i = 0; i < leading; i += 1) {
-      cells.push({ key: `lead-${i}`, blank: true });
-    }
-    for (let day = 1; day <= end.getDate(); day += 1) {
-      const current = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), day);
-      const key = formatDateKey(current);
-      const outOfRange = current < today || current > maxDate;
-      const stats = dateStatsMap.get(key) || { hasAny: false, hasBookable: false };
-      cells.push({
-        key,
-        blank: false,
-        dateKey: key,
-        label: String(day),
-        outOfRange,
-        hasAny: stats.hasAny,
-        hasBookable: stats.hasBookable,
-        selected: selectedDate === key,
-      });
-    }
-    return cells;
-  }, [calendarMonth, dateStatsMap, maxDate, selectedDate, today]);
-
-  async function loadReservations() {
-    const data = await fetchStudentReservations(statusFilter ? { status: statusFilter } : {});
+  const loadReservations = useCallback(async () => {
+    const data = await fetchStudentReservations({});
     setReservations(data.reservations || []);
-  }
+  }, []);
 
-  async function loadSlots() {
-    const data = await fetchStudentReservationSlots();
-    setSlots(data.slots || []);
-    setInstructorAssignmentMode(data?.reservationPolicy?.instructorAssignmentMode || "auto");
-  }
+  const loadLessonTypes = useCallback(async () => {
+    const data = await fetchStudentLessonTypes();
+    setLessonTypes(data.lessonTypes || []);
+  }, []);
 
-  async function loadAll() {
-    setLoading(true);
+  const loadMonthCandidates = useCallback(async () => {
+    if (!selectedLesson?.id) return;
+    setMonthLoading(true);
     setError("");
     try {
-      await Promise.all([loadReservations(), loadSlots()]);
-    } catch (err) {
-      setError(err.message || "予約取得中にエラーが発生しました。");
+      const data = await fetchStudentReservationCandidates({
+        lessonTypeId: selectedLesson.id,
+        fromDate: monthRange.fromDate,
+        toDate: monthRange.toDate,
+        lessonMode: lessonDeliveryType,
+      });
+      setMonthPayload(data);
+    } catch (e) {
+      setError(e.message || "候補の取得に失敗しました。");
+      setMonthPayload(null);
     } finally {
-      setLoading(false);
+      setMonthLoading(false);
     }
-  }
+  }, [selectedLesson?.id, monthRange.fromDate, monthRange.toDate, lessonDeliveryType]);
 
   useEffect(() => {
-    loadAll();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter]);
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        await Promise.all([loadReservations(), loadLessonTypes()]);
+      } catch (e) {
+        if (!cancelled) setError(e.message || "読み込みに失敗しました。");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadReservations, loadLessonTypes]);
 
   useEffect(() => {
     let cancelled = false;
@@ -193,176 +169,151 @@ export default function StudentReservationsApp() {
   }, []);
 
   useEffect(() => {
-    if (!canStudentSelectInstructor) {
-      if (selectedTeacherId) setSelectedTeacherId("");
-      return;
-    }
-    if (!selectedTeacherId) {
-      setSelectedTeacherId(INSTRUCTOR_NO_PREFERENCE);
-      return;
-    }
-    if (selectedTeacherId !== INSTRUCTOR_NO_PREFERENCE && teacherOptions.length > 0) {
-      const exists = teacherOptions.some((teacher) => teacher.id === selectedTeacherId);
-      if (!exists) setSelectedTeacherId(INSTRUCTOR_NO_PREFERENCE);
-    }
-    if (teacherOptions.length === 0 && selectedTeacherId && selectedTeacherId !== INSTRUCTOR_NO_PREFERENCE) {
-      setSelectedTeacherId("");
-    }
-  }, [canStudentSelectInstructor, selectedTeacherId, teacherOptions]);
+    if (step >= 2 && selectedLesson?.id) loadMonthCandidates();
+  }, [step, selectedLesson?.id, loadMonthCandidates]);
+
+  const getDayMeta = useCallback(
+    (dateKey) => {
+      const outOfMonth =
+        dateKey < monthRange.fromDate ||
+        dateKey > monthRange.toDate ||
+        parseDateKey(dateKey) < today ||
+        parseDateKey(dateKey) > maxDate;
+      if (outOfMonth) return { disabled: true, bookable: false, hasSlots: false, hint: "" };
+
+      const ds = (monthPayload?.daySummaries || []).find((x) => x.targetDate === dateKey);
+      if (ds?.daySummary?.closed) {
+        return {
+          disabled: true,
+          bookable: false,
+          hasSlots: false,
+          hint: "休業",
+        };
+      }
+
+      const dayCands = (monthPayload?.candidates || []).filter((c) => c.date === dateKey);
+      if (dayCands.length === 0) {
+        return { disabled: true, bookable: false, hasSlots: false, hint: "枠なし" };
+      }
+      const ok = dayCands.some((c) => c.bookingOk);
+      if (ok) return { disabled: false, bookable: true, hasSlots: true, hint: "" };
+      const first = dayCands[0];
+      const hint = studentFacingUnavailableHint(first.reasonCodes, first.blockReasonsJa);
+      return { disabled: true, bookable: false, hasSlots: true, hint };
+    },
+    [monthPayload, monthRange.fromDate, monthRange.toDate, today, maxDate]
+  );
+
+  const candidatesForSelectedDate = useMemo(() => {
+    if (!selectedDate || !monthPayload?.candidates) return [];
+    return [...monthPayload.candidates]
+      .filter((c) => c.date === selectedDate)
+      .sort((a, b) => String(a.startTime).localeCompare(String(b.startTime)));
+  }, [monthPayload, selectedDate]);
 
   useEffect(() => {
-    if (!selectedDate) {
-      if (firstBookableDate) setSelectedDate(firstBookableDate);
-      else if (availableDateKeys.length > 0) setSelectedDate(availableDateKeys[0]);
-      return;
+    if (selectedDate && selectedCandidate && selectedCandidate.date !== selectedDate) {
+      setSelectedCandidate(null);
     }
-    if (!dateStatsMap.has(selectedDate)) {
-      if (firstBookableDate) setSelectedDate(firstBookableDate);
-      else if (availableDateKeys.length > 0) setSelectedDate(availableDateKeys[0]);
-      else setSelectedDate("");
-    }
-  }, [selectedDate, availableDateKeys, dateStatsMap, firstBookableDate]);
+  }, [selectedDate, selectedCandidate]);
 
   useEffect(() => {
-    if (!selectedDate) return;
-    const picked = parseDateKey(selectedDate);
-    setCalendarMonth(new Date(picked.getFullYear(), picked.getMonth(), 1));
-  }, [selectedDate]);
-
-  useEffect(() => {
-    if (!form.slotId) {
-      const firstBookable = slotsForDate.find((slot) => slot.isBookable);
-      if (firstBookable) setForm((prev) => ({ ...prev, slotId: firstBookable.id }));
+    if (step !== 2 || !monthPayload || monthLoading) return;
+    if (selectedDate) {
+      const m = getDayMeta(selectedDate);
+      if (m.bookable) return;
     }
-  }, [slotsForDate, form.slotId]);
+    const end = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0);
+    for (let day = 1; day <= end.getDate(); day += 1) {
+      const current = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), day);
+      const key = formatDateKey(current);
+      if (getDayMeta(key).bookable) {
+        setSelectedDate(key);
+        return;
+      }
+    }
+    setSelectedDate("");
+  }, [step, monthPayload, monthLoading, calendarMonth, selectedDate, getDayMeta]);
+
+  function resetFlow() {
+    setStep(1);
+    setSelectedLesson(null);
+    setSelectedDate("");
+    setSelectedCandidate(null);
+    setForm({ memo: "" });
+    setMonthPayload(null);
+  }
 
   async function submitReservation() {
+    if (!selectedCandidate?.slotId) return;
     setSaving(true);
     setError("");
     try {
-      const picked = slotsForDate.find((slot) => slot.id === form.slotId);
-      if (!picked || !picked.isBookable) {
-        throw new Error("予約可能な時間を選択してください。");
-      }
-      const payload = buildStudentReservationCreatePayload(form);
+      const payload = buildStudentReservationCreatePayload({
+        slotId: selectedCandidate.slotId,
+        lessonDeliveryType,
+        memo: form.memo,
+      });
       await postStudentReservation(payload);
-      setForm((prev) => ({ ...prev, memo: "" }));
-      setWizardStep(4);
-      await loadAll();
-    } catch (err) {
-      setError(err.message || "予約作成中にエラーが発生しました。");
+      setStep(5);
+      await loadReservations();
+      const res = await fetch("/api/student/lesson-minutes", { credentials: "include" });
+      const data = await res.json();
+      if (data?.ok && data.usage) setLessonUsage(data.usage);
+      await loadMonthCandidates();
+    } catch (e) {
+      setError(e.message || "予約に失敗しました。");
     } finally {
       setSaving(false);
     }
   }
 
-  async function handleReschedule(id) {
-    const slotId = rescheduleSlotByReservation[id];
-    if (!slotId) return;
-    setError("");
-    try {
-      await patchStudentReservation(id, { slotId });
-      await loadAll();
-    } catch (err) {
-      setError(err.message || "予約変更中にエラーが発生しました。");
-    }
-  }
-
   async function handleCancel(id) {
+    setCancelBusy(true);
     setError("");
     try {
       await postStudentReservationCancel(id);
-      await loadAll();
-    } catch (err) {
-      setError(err.message || "予約キャンセル中にエラーが発生しました。");
+      setDetailOpen(false);
+      await loadReservations();
+    } catch (e) {
+      setError(e.message || "キャンセルに失敗しました。");
+    } finally {
+      setCancelBusy(false);
     }
   }
 
-  function resetWizard() {
-    setWizardStep(1);
-    setForm((prev) => ({ ...prev, memo: "" }));
+  async function handleReschedule(id, slotId) {
+    if (!slotId) return;
+    setRescheduleBusy(true);
+    setError("");
+    try {
+      await patchStudentReservation(id, { slotId });
+      setDetailOpen(false);
+      await loadReservations();
+    } catch (e) {
+      setError(e.message || "変更に失敗しました。");
+    } finally {
+      setRescheduleBusy(false);
+    }
   }
 
-  const canNextFromStep1 = Boolean(selectedDate);
-  const canNextFromStep2 = Boolean(form.slotId && selectedSlot?.isBookable);
-  const canNextFromStep3 = Boolean(form.lessonDeliveryType);
+  const canNext =
+    (step === 1 && selectedLesson) ||
+    (step === 2 && selectedDate && getDayMeta(selectedDate).bookable) ||
+    (step === 3 && selectedCandidate?.bookingOk) ||
+    step === 4;
 
-  const manageReservations = useMemo(
-    () =>
-      reservations.filter(
-        (item) =>
-          item.selfService?.canStudentChange ||
-          item.selfService?.canStudentCancel ||
-          item.status === "requested" ||
-          item.status === "confirmed" ||
-          item.status === "change_requested"
-      ),
-    [reservations]
-  );
-
-  function renderReservationCard(item, { compactActions = false } = {}) {
-    const selfService = item.selfService || {};
-    const st = statusMeta(item.status, item.attendanceStatus);
-    return (
-      <article key={item.id} className={v2.listCard}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
-          <div>
-            <strong>
-              {item.date} {item.time}
-            </strong>
-            <p className={v2.hint}>
-              {lessonDeliveryLabel(item.lessonDeliveryType)} / 担当: {item.instructorName || "-"}
-            </p>
-          </div>
-          <span className={`${v2.badge} ${badgeClass(st.tone)}`}>{st.label}</span>
-        </div>
-        {!compactActions ? (
-          <p className={v2.hint}>
-            変更: {selfService.canStudentChange ? "可" : "不可"} / キャンセル: {selfService.canStudentCancel ? "可" : "不可"}
-          </p>
-        ) : null}
-        <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 8 }}>
-          {selfService.canStudentChange ? (
-            <>
-              <select
-                className={`${styles.field} ${v2.field}`}
-                value={rescheduleSlotByReservation[item.id] || ""}
-                onChange={(e) =>
-                  setRescheduleSlotByReservation((prev) => ({ ...prev, [item.id]: e.target.value }))
-                }
-              >
-                <option value="">変更先の時間を選択</option>
-                {bookableSlots
-                  .filter((slot) => slot.id !== item.slotId)
-                  .map((slot) => (
-                    <option key={slot.id} value={slot.id}>
-                      {slotLabel(slot)}
-                    </option>
-                  ))}
-              </select>
-              <button className={styles.button} type="button" onClick={() => handleReschedule(item.id)}>
-                予約を変更する
-              </button>
-            </>
-          ) : null}
-          {selfService.canStudentCancel ? (
-            <button className={styles.button} type="button" onClick={() => handleCancel(item.id)}>
-              キャンセルする
-            </button>
-          ) : null}
-          {(!selfService.canStudentChange || !selfService.canStudentCancel) &&
-          (selfService.blockedReasonChange || selfService.blockedReasonCancel) ? (
-            <p className={styles.description}>{blockedText(selfService.blockedReasonChange || selfService.blockedReasonCancel)}</p>
-          ) : null}
-        </div>
-      </article>
-    );
+  function goNext() {
+    if (step < 4) setStep((s) => s + 1);
+    else if (step === 4) submitReservation();
   }
 
-  const stepTitle = ["", "日付を選ぶ", "時間を選ぶ", "内容を確認する", "予約完了"][wizardStep] || "";
+  function goBack() {
+    if (step > 1) setStep((s) => Math.max(1, s - 1));
+  }
 
   return (
-    <div className={v2.root}>
+    <div className={flow.flowRoot}>
       <div className={v2.tabBar} role="tablist" aria-label="予約メニュー">
         <button
           type="button"
@@ -371,7 +322,7 @@ export default function StudentReservationsApp() {
           className={`${v2.tab} ${mainTab === "reserve" ? v2.tabActive : ""}`}
           onClick={() => {
             setMainTab("reserve");
-            if (wizardStep === 4) resetWizard();
+            if (step === 5) resetFlow();
           }}
         >
           予約する
@@ -385,182 +336,26 @@ export default function StudentReservationsApp() {
         >
           予約一覧
         </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={mainTab === "manage"}
-          className={`${v2.tab} ${mainTab === "manage" ? v2.tabActive : ""}`}
-          onClick={() => setMainTab("manage")}
-        >
-          キャンセル・変更
-        </button>
       </div>
 
       {error ? <p className={`${styles.message} ${styles.messageError}`}>{error}</p> : null}
       {loading ? <p className={styles.description}>読み込み中...</p> : null}
 
-      {mainTab === "reserve" && lessonUsage ? (
-        <div className={v2.lessonMinutesReserveHint} data-attention={lessonUsage.minutesAttention || "ok"}>
-          <p className={v2.lessonMinutesReserveHintText}>
-            いまの残りは <strong>{lessonUsage.lessonMinutes?.remainingMinutes ?? 0}分</strong> です。
-            {lessonUsage.minutesAttention === "exhausted"
-              ? " このままでは新しい予約が難しい場合があります。教室へご相談ください。"
-              : lessonUsage.minutesAttention === "low"
-                ? " そろそろ時間の追加を検討されると安心です。"
-                : lessonUsage.minutesAttention === "next_short"
-                  ? " 次のレッスン後に不足する見込みがあります。必要なら教室へ。"
-                  : " 枠の長さと照らして、足りるか軽く確認してください。"}
-          </p>
-          <Link className={v2.lessonMinutesReserveHintLink} href="/student/lesson-time">
-            レッスン時間の記録を見る
-          </Link>
-        </div>
-      ) : null}
-
       {mainTab === "reserve" ? (
         <>
-          {wizardStep < 4 ? (
-            <div className={v2.wizardHeader}>
-              <h2 className={styles.sectionTitle} style={{ margin: 0 }}>
-                {stepTitle}
-              </h2>
-              <div className={v2.stepDots} aria-hidden>
-                {[1, 2, 3].map((s) => (
-                  <span
-                    key={s}
-                    className={`${v2.stepDot} ${wizardStep === s ? v2.stepDotActive : ""} ${
-                      wizardStep > s ? v2.stepDotDone : ""
-                    }`}
-                  />
-                ))}
-              </div>
-            </div>
-          ) : null}
+          <StudentReservationSummary
+            remainingMinutes={remainingMinutes}
+            bookableMinutes={bookableMinutes}
+            nextReservationLabel={nextReservationLabel}
+            useMinutes={useMinutes}
+            afterMinutes={selectedLesson && (selectedCandidate || step >= 3) ? afterMinutes : null}
+            loading={loading}
+          />
 
-          {wizardStep === 1 ? (
-            <section>
-              {canStudentSelectInstructor && teacherOptions.length > 0 ? (
-                <label className={styles.label}>
-                  講師（任意）
-                  <select
-                    className={styles.field}
-                    value={selectedTeacherId}
-                    onChange={(e) => setSelectedTeacherId(e.target.value)}
-                  >
-                    <option value={INSTRUCTOR_NO_PREFERENCE}>指定なし（教室で調整）</option>
-                    {teacherOptions.map((t) => (
-                      <option key={t.id} value={t.id}>
-                        {t.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              ) : null}
-              <label className={styles.label}>
-                日付
-                <div className={v2.calendarHeader}>
-                  <button
-                    className={styles.optionButton}
-                    type="button"
-                    onClick={() => setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1))}
-                    disabled={
-                      new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1) <=
-                      new Date(today.getFullYear(), today.getMonth(), 1)
-                    }
-                  >
-                    前月
-                  </button>
-                  <strong>
-                    {calendarMonth.getFullYear()}年 {calendarMonth.getMonth() + 1}月
-                  </strong>
-                  <button
-                    className={styles.optionButton}
-                    type="button"
-                    onClick={() => setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1))}
-                    disabled={
-                      new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0) >= maxDate
-                    }
-                  >
-                    翌月
-                  </button>
-                </div>
-                <div className={v2.calendarWeekdays}>
-                  {["日", "月", "火", "水", "木", "金", "土"].map((w) => (
-                    <span key={w}>{w}</span>
-                  ))}
-                </div>
-                <div className={v2.calendarGrid}>
-                  {calendarCells.map((cell) => {
-                    if (cell.blank) return <span key={cell.key} className={v2.calendarBlank} />;
-                    const disabled = cell.outOfRange || !cell.hasAny;
-                    return (
-                      <button
-                        key={cell.key}
-                        type="button"
-                        disabled={disabled}
-                        className={`${v2.calendarDay} ${
-                          cell.selected
-                            ? v2.calendarDaySelected
-                            : disabled
-                              ? v2.calendarDayUnavailable
-                              : cell.hasBookable
-                                ? v2.calendarDayAvailable
-                                : v2.calendarDayLimited
-                        }`}
-                        onClick={() => {
-                          if (disabled) return;
-                          setSelectedDate(cell.dateKey);
-                          setForm((prev) => ({ ...prev, slotId: "" }));
-                        }}
-                      >
-                        {cell.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </label>
-            </section>
-          ) : null}
-
-          {wizardStep === 2 ? (
-            <section>
-              <p className={styles.description}>{selectedDate} の時間を選んでください。</p>
-              <div className={v2.timeGrid}>
-                {slotsForDate.map((slot) => (
-                  <button
-                    key={slot.id}
-                    type="button"
-                    disabled={!slot.isBookable}
-                    className={`${v2.timeBtn} ${form.slotId === slot.id ? v2.timeBtnSelected : ""}`}
-                    onClick={() => setForm((prev) => ({ ...prev, slotId: slot.id }))}
-                  >
-                    {slot.time}
-                  </button>
-                ))}
-              </div>
-              {slotsForDate.length === 0 ? <p className={styles.description}>この日は枠がありません。</p> : null}
-            </section>
-          ) : null}
-
-          {wizardStep === 3 ? (
-            <section>
-              <div className={v2.summaryCard}>
-                <p>
-                  <strong>日付:</strong> {selectedDate}
-                </p>
-                <p>
-                  <strong>時間:</strong> {selectedSlot?.time || "-"}（{selectedSlot?.durationMinutes || "-"}分）
-                </p>
-                <p>
-                  <strong>講師:</strong> {selectedSlot?.instructorName || "調整"}
-                </p>
-                <p>
-                  <strong>形式:</strong> {lessonDeliveryLabel(form.lessonDeliveryType)}
-                </p>
-              </div>
-              <label className={styles.label} style={{ marginTop: "0.75rem" }}>
-                レッスン形式
-                <div className={v2.optionRow}>
+          {step < 5 ? (
+            <div className={flow.pcLayout}>
+              <div>
+                <div className={flow.deliveryRow} role="group" aria-label="レッスン形式">
                   {[
                     { id: "in_person", label: "対面" },
                     { id: "online", label: "オンライン" },
@@ -568,85 +363,160 @@ export default function StudentReservationsApp() {
                     <button
                       key={opt.id}
                       type="button"
-                      className={`${v2.optionChip} ${form.lessonDeliveryType === opt.id ? v2.optionChipSelected : ""}`}
-                      onClick={() => setForm((prev) => ({ ...prev, lessonDeliveryType: opt.id }))}
+                      className={`${flow.deliveryChip} ${lessonDeliveryType === opt.id ? flow.deliveryChipOn : ""}`}
+                      onClick={() => {
+                        setLessonDeliveryType(opt.id);
+                        setSelectedDate("");
+                        setSelectedCandidate(null);
+                        if (selectedLesson) setStep(2);
+                      }}
                     >
                       {opt.label}
                     </button>
                   ))}
                 </div>
-              </label>
-              <label className={styles.label}>
-                伝えたいこと（任意）
-                <input
-                  className={styles.field}
-                  value={form.memo}
-                  onChange={(e) => setForm((prev) => ({ ...prev, memo: e.target.value }))}
-                  placeholder="教室への連絡事項"
-                />
-              </label>
-            </section>
-          ) : null}
 
-          {wizardStep === 4 ? (
+                <div className={flow.stepHeader}>
+                  <h2 className={flow.stepTitle}>
+                    STEP {step} / {STEPS[step - 1]}
+                  </h2>
+                  <div className={flow.stepTrack} aria-hidden>
+                    {STEPS.slice(0, 4).map((lab, i) => (
+                      <span
+                        key={lab}
+                        className={`${flow.stepPill} ${step === i + 1 ? flow.stepPillOn : ""} ${
+                          step > i + 1 ? flow.stepPillDone : ""
+                        }`}
+                      >
+                        {i + 1}. {lab}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {monthLoading && step >= 2 ? <p className={flow.hint}>日程を読み込み中…</p> : null}
+
+                {step === 1 ? (
+                  <section>
+                    <p className={flow.hint}>予約したいレッスンを選んでください（所要時間が決まります）。</p>
+                    <div className={flow.lessonGrid}>
+                      {lessonTypes.map((lt) => (
+                        <LessonTypeCard
+                          key={lt.id}
+                          lesson={lt}
+                          selected={selectedLesson?.id === lt.id}
+                          deliveryLabel={deliveryLabelShort(lessonDeliveryType)}
+                          onSelect={(l) => {
+                            setSelectedLesson(l);
+                            setSelectedDate("");
+                            setSelectedCandidate(null);
+                          }}
+                        />
+                      ))}
+                    </div>
+                    {!lessonTypes.length && !loading ? (
+                      <p className={flow.hint}>現在、学生から選べるレッスンがありません。教室にお問い合わせください。</p>
+                    ) : null}
+                  </section>
+                ) : null}
+
+                {step === 2 ? (
+                  <section>
+                    <p className={flow.hint}>予約する日付を選んでください。グレー表示の日は選べません。</p>
+                    <StudentReservationCalendar
+                      calendarMonth={calendarMonth}
+                      today={today}
+                      maxDate={maxDate}
+                      selectedDate={selectedDate}
+                      onSelectDate={(k) => {
+                        setSelectedDate(k);
+                        setSelectedCandidate(null);
+                      }}
+                      onPrevMonth={() =>
+                        setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1))
+                      }
+                      onNextMonth={() =>
+                        setCalendarMonth((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1))
+                      }
+                      getDayMeta={getDayMeta}
+                    />
+                  </section>
+                ) : null}
+
+                {step === 3 ? (
+                  <section>
+                    <p className={flow.hint}>
+                      {selectedDate} の開始時間を選んでください（タップで選択）。
+                    </p>
+                    <StudentTimeCandidateList
+                      candidates={candidatesForSelectedDate}
+                      selectedSlotId={selectedCandidate?.slotId || ""}
+                      onSelect={(c) => setSelectedCandidate(c)}
+                    />
+                  </section>
+                ) : null}
+
+                {step === 4 ? (
+                  <section>
+                    <p className={flow.hint}>内容を確認して、問題なければ予約を確定してください。</p>
+                    <StudentReservationConfirmCard
+                      lessonName={selectedLesson?.displayName}
+                      date={selectedDate}
+                      startTime={selectedCandidate?.startTime}
+                      endTime={selectedCandidate?.endTime}
+                      teacherName={selectedCandidate?.teacherName}
+                      durationMinutes={selectedLesson?.durationMinutes}
+                      useMinutes={useMinutes}
+                      afterMinutes={afterMinutes}
+                      deliveryType={lessonDeliveryType}
+                      memo={form.memo}
+                      onMemoChange={(v) => setForm((p) => ({ ...p, memo: v }))}
+                    />
+                  </section>
+                ) : null}
+              </div>
+
+              {step === 4 ? (
+                <aside className={flow.pcSticky}>
+                  <div className={flow.impactBox}>
+                    <div className={flow.impactTitle}>予約ボタンの前にご確認</div>
+                    <div className={flow.impactLine}>今回使う時間: {useMinutes != null ? `${useMinutes}分` : "—"}</div>
+                    <div className={flow.impactLine} style={{ marginTop: "0.35rem" }}>
+                      予約後の残り: {afterMinutes != null ? `${afterMinutes}分` : "—"}
+                    </div>
+                  </div>
+                </aside>
+              ) : null}
+            </div>
+          ) : (
             <section className={v2.successCard}>
               <h2 className={styles.sectionTitle} style={{ marginTop: 0 }}>
-                予約完了
+                予約を受け付けました
               </h2>
-              <p className={styles.description}>申し込みを受け付けました。予約一覧で状態をご確認ください。</p>
+              <p className={styles.description}>予約一覧で状態をご確認ください。変更・キャンセルが可能な場合は一覧から操作できます。</p>
               <button className={styles.button} type="button" onClick={() => setMainTab("list")}>
                 予約一覧へ
               </button>
-              <button className={styles.button} type="button" style={{ marginTop: 8 }} onClick={resetWizard}>
+              <button className={styles.button} type="button" style={{ marginTop: 8 }} onClick={resetFlow}>
                 続けて予約する
               </button>
             </section>
-          ) : null}
+          )}
 
-          {wizardStep >= 1 && wizardStep <= 3 ? (
-            <div className={v2.bottomBar}>
-              <div className={v2.bottomBarInner}>
-                {wizardStep > 1 ? (
-                  <button
-                    type="button"
-                    className={v2.bottomBtn}
-                    onClick={() => setWizardStep((s) => Math.max(1, s - 1))}
-                  >
-                    戻る
-                  </button>
-                ) : (
-                  <span />
-                )}
-                {wizardStep === 1 ? (
-                  <button
-                    type="button"
-                    className={`${v2.bottomBtn} ${v2.bottomBtnPrimary}`}
-                    disabled={!canNextFromStep1}
-                    onClick={() => setWizardStep(2)}
-                  >
-                    次へ
-                  </button>
-                ) : null}
-                {wizardStep === 2 ? (
-                  <button
-                    type="button"
-                    className={`${v2.bottomBtn} ${v2.bottomBtnPrimary}`}
-                    disabled={!canNextFromStep2}
-                    onClick={() => setWizardStep(3)}
-                  >
-                    次へ
-                  </button>
-                ) : null}
-                {wizardStep === 3 ? (
-                  <button
-                    type="button"
-                    className={`${v2.bottomBtn} ${v2.bottomBtnPrimary}`}
-                    disabled={!canNextFromStep3 || bookableSlots.length === 0 || saving}
-                    onClick={() => submitReservation()}
-                  >
-                    {saving ? "送信中..." : "予約を申し込む"}
-                  </button>
-                ) : null}
+          {step >= 1 && step <= 4 ? (
+            <div className={flow.bottomBar}>
+              <div className={flow.bottomInner}>
+                <button type="button" className={flow.bottomBtn} onClick={goBack} disabled={step === 1 || saving}>
+                  戻る
+                </button>
+                <button
+                  type="button"
+                  className={`${flow.bottomBtn} ${flow.bottomPrimary}`}
+                  disabled={!canNext || saving || (step === 2 && monthLoading)}
+                  onClick={goNext}
+                >
+                  {step === 4 ? (saving ? "送信中…" : "予約を確定する") : "次へ"}
+                </button>
               </div>
             </div>
           ) : null}
@@ -655,36 +525,49 @@ export default function StudentReservationsApp() {
 
       {mainTab === "list" ? (
         <section>
-          <label className={styles.label}>
-            状態
-            <select
-              className={styles.field}
-              value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
-            >
-              <option value="">すべて</option>
-              <option value="requested">予約申請中</option>
-              <option value="confirmed">予約確定</option>
-              <option value="change_requested">変更依頼</option>
-              <option value="rejected">却下</option>
-              <option value="cancelled">キャンセル</option>
-              <option value="completed">完了</option>
-            </select>
-          </label>
-          {reservations.map((item) => renderReservationCard(item))}
+          <p className={flow.hint}>行をタップすると詳細・変更・キャンセルができます。</p>
+          {reservations.map((item) => {
+            const st = statusMeta(item.status, item.attendanceStatus);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className={flow.listCard}
+                onClick={() => {
+                  setDetailReservation(item);
+                  setDetailOpen(true);
+                }}
+              >
+                <div className={flow.listCardHead}>
+                  <div>
+                    <strong>
+                      {item.date} {String(item.time || "").slice(0, 5)}
+                    </strong>
+                    <p className={flow.hint} style={{ margin: "0.25rem 0 0" }}>
+                      {item.lessonServiceNameJa || "レッスン"} · {lessonDeliveryLabel(item.lessonDeliveryType)}
+                    </p>
+                    <p className={flow.hint} style={{ margin: "0.15rem 0 0" }}>
+                      担当: {item.instructorName || "—"}
+                    </p>
+                  </div>
+                  <span className={`${flow.badge} ${badgeToneClass(st.tone)}`}>{st.label}</span>
+                </div>
+              </button>
+            );
+          })}
           {!loading && reservations.length === 0 ? <p className={styles.description}>予約がありません。</p> : null}
         </section>
       ) : null}
 
-      {mainTab === "manage" ? (
-        <section>
-          <p className={styles.description}>変更・キャンセルが必要な予約から操作できます。</p>
-          {manageReservations.map((item) => renderReservationCard(item, { compactActions: true }))}
-          {!loading && manageReservations.length === 0 ? (
-            <p className={styles.description}>対象の予約はありません。</p>
-          ) : null}
-        </section>
-      ) : null}
+      <StudentReservationDetailModal
+        open={detailOpen}
+        reservation={detailReservation}
+        onClose={() => setDetailOpen(false)}
+        onCancel={handleCancel}
+        onReschedule={handleReschedule}
+        cancelBusy={cancelBusy}
+        rescheduleBusy={rescheduleBusy}
+      />
 
       <p className={v2.rollbackHint}>
         画面が不安定な場合は{" "}

--- a/features/reservations/ui/student/StudentTimeCandidateList.js
+++ b/features/reservations/ui/student/StudentTimeCandidateList.js
@@ -1,0 +1,37 @@
+"use client";
+
+import { studentFacingUnavailableHint } from "../../../../lib/student/studentReservationReasonStudentJa";
+import flow from "./student-reservation-flow.module.css";
+
+export default function StudentTimeCandidateList({ candidates = [], selectedSlotId, onSelect }) {
+  if (!candidates.length) {
+    return <p className={flow.hint}>この日は予約できる時間がありません。</p>;
+  }
+  return (
+    <div className={flow.timeGrid}>
+      {candidates.map((c) => {
+        const ok = Boolean(c.bookingOk);
+        const hint = ok ? "" : studentFacingUnavailableHint(c.reasonCodes, c.blockReasonsJa);
+        return (
+          <button
+            key={c.slotId}
+            type="button"
+            disabled={!ok}
+            title={hint || undefined}
+            className={`${flow.timeBtn} ${selectedSlotId === c.slotId ? flow.timeBtnSel : ""}`}
+            onClick={() => {
+              if (ok) onSelect(c);
+            }}
+          >
+            {c.startTime}
+            <span className={flow.timeSub}>
+              {c.endTime ? `〜${c.endTime}` : ""}
+              {c.teacherName ? ` · ${c.teacherName}` : ""}
+              {c.availableCount != null && c.capacity != null ? ` · 残${c.availableCount}` : ""}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/features/reservations/ui/student/student-reservation-flow.module.css
+++ b/features/reservations/ui/student/student-reservation-flow.module.css
@@ -1,0 +1,530 @@
+.flowRoot {
+  padding-bottom: 6rem;
+}
+
+.summaryGrid {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.summaryCard {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.55rem 0.65rem;
+  min-height: 4.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.summaryLabel {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #64748b;
+  letter-spacing: 0.02em;
+}
+
+.summaryValue {
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.summaryHint {
+  font-size: 0.65rem;
+  color: #94a3b8;
+  line-height: 1.35;
+}
+
+.deliveryRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.deliveryChip {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  background: #fff;
+  cursor: pointer;
+}
+
+.deliveryChipOn {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.stepHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.65rem;
+}
+
+.stepTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.stepTrack {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.stepPill {
+  font-size: 0.62rem;
+  font-weight: 800;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  color: #94a3b8;
+  background: #f8fafc;
+}
+
+.stepPillOn {
+  border-color: #93c5fd;
+  color: #1d4ed8;
+  background: #eff6ff;
+}
+
+.stepPillDone {
+  border-color: #86efac;
+  color: #166534;
+  background: #f0fdf4;
+}
+
+.lessonGrid {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
+.lessonCard {
+  text-align: left;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.65rem 0.7rem;
+  background: #fff;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.lessonCard:hover {
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+}
+
+.lessonCardOn {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 1px #bfdbfe;
+}
+
+.lessonName {
+  font-weight: 800;
+  font-size: 0.88rem;
+  color: #0f172a;
+}
+
+.lessonMeta {
+  font-size: 0.72rem;
+  color: #64748b;
+  margin-top: 0.25rem;
+}
+
+.calHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.45rem;
+}
+
+.calNav {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.calNav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.calWeekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  font-size: 0.68rem;
+  color: #64748b;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.calGrid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.calBlank {
+  min-height: 2.35rem;
+}
+
+.calDay {
+  min-height: 2.35rem;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  position: relative;
+}
+
+.calDay:disabled {
+  opacity: 0.32;
+  cursor: not-allowed;
+}
+
+.calDayOk {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.calDayWeak {
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.calDaySel {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.dayHint {
+  display: block;
+  font-size: 0.55rem;
+  font-weight: 600;
+  color: #94a3b8;
+  line-height: 1.1;
+  margin-top: 1px;
+  padding: 0 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.timeBtn {
+  min-width: 4.6rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  font-size: 0.82rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.timeBtn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.timeBtnSel {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.timeSub {
+  display: block;
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: #64748b;
+  margin-top: 0.15rem;
+}
+
+.confirmCard {
+  border: 1px solid #cbd5e1;
+  border-radius: 14px;
+  padding: 0.85rem;
+  background: #f8fafc;
+}
+
+.confirmRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.confirmRow:last-child {
+  border-bottom: none;
+}
+
+.confirmKey {
+  color: #64748b;
+  font-weight: 700;
+}
+
+.confirmVal {
+  color: #0f172a;
+  font-weight: 700;
+  text-align: right;
+}
+
+.impactBox {
+  margin-top: 0.65rem;
+  padding: 0.65rem;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #bfdbfe;
+}
+
+.impactTitle {
+  font-size: 0.72rem;
+  font-weight: 800;
+  color: #1d4ed8;
+  margin-bottom: 0.35rem;
+}
+
+.impactLine {
+  font-size: 0.88rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.bottomBar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.96);
+  border-top: 1px solid #e2e8f0;
+  padding: 0.55rem 0.75rem calc(0.55rem + env(safe-area-inset-bottom));
+  backdrop-filter: blur(8px);
+}
+
+.bottomInner {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.bottomBtn {
+  flex: 1;
+  min-height: 2.65rem;
+  border-radius: 12px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  font-weight: 800;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.bottomPrimary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.bottomBtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.badgePending {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badgeConfirmed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badgeCancelled {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.badgeCompleted {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
+.listCard {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  margin-bottom: 0.5rem;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.listCardHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.modalRoot {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0;
+}
+
+@media (min-width: 640px) {
+  .modalRoot {
+    align-items: center;
+    padding: 1rem;
+  }
+}
+
+.modalBackdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  border: none;
+  cursor: pointer;
+}
+
+.modalCard {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  max-height: min(90vh, 640px);
+  overflow: auto;
+  background: #fff;
+  border-radius: 16px 16px 0 0;
+  padding: 1rem 1rem 1.25rem;
+  box-shadow: 0 -8px 32px rgba(15, 23, 42, 0.12);
+}
+
+@media (min-width: 640px) {
+  .modalCard {
+    border-radius: 16px;
+  }
+}
+
+.modalClose {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.55rem;
+  border: none;
+  background: transparent;
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.modalTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.modalActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+}
+
+.modalBtn {
+  min-height: 2.4rem;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  font-weight: 800;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.modalBtnPrimary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+.modalBtnDanger {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.field {
+  width: 100%;
+  min-height: 2.35rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.4rem 0.55rem;
+  font-size: 0.85rem;
+}
+
+.hint {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin: 0.35rem 0 0;
+}
+
+.pcLayout {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .pcLayout {
+    grid-template-columns: 1fr 320px;
+    align-items: start;
+  }
+
+  .pcSticky {
+    position: sticky;
+    top: 0.5rem;
+  }
+}

--- a/lib/adapters/studentReservationClient.js
+++ b/lib/adapters/studentReservationClient.js
@@ -13,6 +13,15 @@ export async function fetchStudentReservations(filters = {}) {
   return data;
 }
 
+export async function fetchStudentLessonTypes() {
+  const response = await fetch("/api/student/lesson-types", { cache: "no-store" });
+  const data = await response.json();
+  if (!response.ok || !data?.ok) {
+    throw new Error(data?.error || "レッスン一覧の取得に失敗しました。");
+  }
+  return data;
+}
+
 export async function fetchStudentReservationSlots() {
   const response = await fetch("/api/student/reservation-slots");
   const data = await response.json();

--- a/lib/student/studentReservationReasonStudentJa.js
+++ b/lib/student/studentReservationReasonStudentJa.js
@@ -1,0 +1,49 @@
+/**
+ * 学生向け：エンジン reason code / 文言を短く分かりやすく（ポイントは伏せる）
+ */
+
+import { ReasonCodes } from "../reservations/engine/reasonCodes.js";
+
+const BY_CODE = {
+  [ReasonCodes.CLASSROOM_CLOSED]: "この日は休業です",
+  [ReasonCodes.OUTSIDE_BUSINESS_HOURS]: "この時間は受付できません",
+  [ReasonCodes.CLASSROOM_BREAK]: "休憩時間のため選べません",
+  [ReasonCodes.TEACHER_UNAVAILABLE]: "対応可能な講師がいません",
+  [ReasonCodes.TEACHER_BREAK]: "講師の休憩時間です",
+  [ReasonCodes.INSUFFICIENT_DURATION_WINDOW]: "必要な時間を確保できません",
+  [ReasonCodes.SLOT_CLOSED]: "この枠は閉じられています",
+  [ReasonCodes.POLICY_DEADLINE_PASSED]: "受付終了しました",
+  [ReasonCodes.POLICY_LEAD_TIME]: "準備時間が足りません",
+  [ReasonCodes.INSUFFICIENT_POINTS]: "この枠は現在お選びいただけません",
+  [ReasonCodes.INSUFFICIENT_MINUTES]: "残り時間が不足しています",
+  [ReasonCodes.RESERVATION_CONFLICT]: "同じ時間に別の予約があります",
+  [ReasonCodes.INSTRUCTOR_CONFLICT]: "講師の都合で選べません",
+  [ReasonCodes.LESSON_NOT_SUPPORTED_BY_TEACHER]: "この講師ではこのレッスンを受けられません",
+  [ReasonCodes.DELIVERY_MISMATCH]: "対面/オンラインの組み合わせが合いません",
+  [ReasonCodes.DURATION_MISMATCH]: "枠の長さがレッスンと合いません",
+  [ReasonCodes.CAPACITY_FULL]: "定員に達しています",
+  [ReasonCodes.SLOT_STARTED]: "開始時刻を過ぎています",
+  [ReasonCodes.LESSON_DISABLED]: "このレッスンは選べません",
+  [ReasonCodes.TEACHER_FILTER_MISMATCH]: "講師の指定と枠が合いません",
+  [ReasonCodes.UNKNOWN]: "この日は予約できません",
+};
+
+/**
+ * @param {string[]} codes
+ * @param {string[]} blockReasonsJa
+ */
+export function studentFacingUnavailableHint(codes = [], blockReasonsJa = []) {
+  const list = Array.isArray(codes) ? codes : [];
+  for (const c of list) {
+    const key = String(c || "").trim();
+    if (BY_CODE[key]) return BY_CODE[key];
+  }
+  const ja = Array.isArray(blockReasonsJa) ? blockReasonsJa.filter(Boolean) : [];
+  if (ja.length) {
+    const s = String(ja[0]);
+    if (s.includes("ポイント")) return BY_CODE[ReasonCodes.INSUFFICIENT_POINTS];
+    if (s.includes("レッスン時間") && s.includes("不足")) return BY_CODE[ReasonCodes.INSUFFICIENT_MINUTES];
+    return s.length > 36 ? `${s.slice(0, 34)}…` : s;
+  }
+  return BY_CODE[ReasonCodes.UNKNOWN];
+}

--- a/scripts/deploy.env.example
+++ b/scripts/deploy.env.example
@@ -1,7 +1,12 @@
 # Copy to scripts/deploy.env (ignored by Git) and edit.
 
+# --- 로컬 스크립트 (deploy-from-local.sh 등) ---
 # SSH target for deployment (user@host or alias from ~/.ssh/config)
 MALMOI_DEPLOY_SSH=malmoi_deploy@YOUR_SERVER_HOST
+
+# --- GitHub Actions「Deploy production (manual)」(.github/workflows/deploy-production.yml) ---
+# Repository Secrets: DEPLOY_HOST, DEPLOY_USER, DEPLOY_PORT, DEPLOY_APP_DIR, DEPLOY_SSH_KEY
+# (push 자동 배포 deploy-main.yml 은 기존 MALMOI_DEPLOY_* Secrets 사용)
 
 # Optional: path to deploy script on server (default matches repo layout)
 # MALMOI_REMOTE_DEPLOY_SCRIPT=/home/malmoi_deploy/apps/malmoi/deploy/deploy-prod.sh


### PR DESCRIPTION
- add deploy-production.yml manual workflow
- add one-click deploy docs
- update related deploy workflow references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new production deployment pathway via GitHub Actions and changes the student reservations V2 booking/reschedule UI and related API calls, which can impact release operations and core user flows. Main risks are misconfigured secrets/branch checkout during deploy and regressions in booking UX/state handling.
> 
> **Overview**
> **Adds one-click manual production deploy via GitHub Actions.** Introduces `deploy-production.yml` (`workflow_dispatch`) that SSHs to the server, checks out/pulls a specified branch, runs `deploy/deploy-prod.sh`, and performs service/health checks; docs/README and `docs/deploy-one-click-ko.md` document required secrets and usage.
> 
> **Makes server deploy script branch/path-aware.** `deploy/deploy-prod.sh` now supports overriding `APP_DIR` and `GIT_REF` (via env) and switches both release and non-release modes to `git checkout -B <ref> origin/<ref>` + ff-only pulls.
> 
> **Revamps student reservations V2 to a lesson→date→time step flow.** `StudentReservationsApp` is refactored to use `fetchStudentLessonTypes` and `fetchStudentReservationCandidates`, adds a time/minutes summary, calendar/day availability hints, and a detail modal that supports reschedule/cancel using candidates, plus new UI components/styles and student-friendly unavailability messages (`studentReservationReasonStudentJa`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f461547a06631a48d522dc02b4076bb5a1863a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->